### PR TITLE
Stop clear Google Play Services data

### DIFF
--- a/Module/Yuri/kill_all.sh
+++ b/Module/Yuri/kill_all.sh
@@ -9,7 +9,7 @@ log_message "Start"
 
 # Writing
 log_message "Writing"
-PKGS="com.android.vending com.google.android.gsf com.google.android.gms com.google.android.contactkeys com.google.android.ims com.google.android.safetycore com.google.android.apps.walletnfcrel com.google.android.apps.nbu.paisa.user com.zhenxi.hunter com.reveny.nativecheck io.github.vvb2060.keyattestation io.github.vvb2060.mahoshojo icu.nullptr.nativetest com.android.nativetest io.liankong.riskdetector me.garfieldhan.holmes luna.safe.luna com.zhenxi.hunter gr.nikolasspyr.integritycheck com.youhu.laifu"
+PKGS="com.android.vending com.google.android.gsf com.google.android.contactkeys com.google.android.ims com.google.android.safetycore com.google.android.apps.walletnfcrel com.google.android.apps.nbu.paisa.user com.zhenxi.hunter com.reveny.nativecheck io.github.vvb2060.keyattestation io.github.vvb2060.mahoshojo icu.nullptr.nativetest com.android.nativetest io.liankong.riskdetector me.garfieldhan.holmes luna.safe.luna com.zhenxi.hunter gr.nikolasspyr.integritycheck com.youhu.laifu"
 
 for pkg in $PKGS; do
     if ! am force-stop "$pkg" >/dev/null 2>&1; then


### PR DESCRIPTION
Why I said that? Clearing it won't help to pass Integrity, instead you will be logged out accounts and even more pain with GmsCore.
So stop clear that app data and let user decide that, not automatically